### PR TITLE
Check AbstractCollection $this->_collectionName in init()

### DIFF
--- a/Core/Rubedo/Collection/AbstractCollection.php
+++ b/Core/Rubedo/Collection/AbstractCollection.php
@@ -80,6 +80,9 @@ abstract class AbstractCollection implements IAbstractCollection
     {
         // init the data access service
         $this->_dataService = Manager::getService('MongoDataAccess');
+        if ($this->_collectionName == "") {
+          $this->_collectionName="AbstractCollection";
+        }
         $this->_dataService->init($this->_collectionName);
     }
 


### PR DESCRIPTION
During install process there's a call to _init() without having previously set up $this->_collectionName. The result is a crash during install. I guess there's a child class which does not overwrites this init function

With this slight change in the code we ensure that this case will never trigger a crash
