### PR TITLE
Fix bug for base64 image Encoding (no type -> no display in Internet …

### DIFF
--- a/module/Rubedo/src/Rubedo/Backoffice/Controller/XhrEncodeImageController.php
+++ b/module/Rubedo/src/Rubedo/Backoffice/Controller/XhrEncodeImageController.php
@@ -42,9 +42,10 @@ class XhrEncodeImageController extends AbstractActionController
     {
         $image = $this->params()->fromFiles('image');
         $path = $image["tmp_name"];
-        $type = pathinfo($path, PATHINFO_EXTENSION);
+        $finfo = new \finfo(FILEINFO_MIME);
+        $type = $finfo->file($path);
         $data = file_get_contents($path);
-        $base64 = 'data:image/' . $type . ';base64,' . base64_encode($data);
+        $base64 = 'data:' . $type . ';base64,' . base64_encode($data);
         $returnArray=array(
             "success"=>true,
             "base64"=>$base64


### PR DESCRIPTION
…Explorer)

This is a quick fix for php 5.3, we had trouble showing image in ie 11 because there was no type in the base64 encoding, with chrome and firefow this is not a problème but with internet Explorer this is
