### PR TITLE
feat: Set package type for composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,6 @@
 {
     "name": "webtales/rubedo",
+    "type": "rubedo-core",
     "description":"An open source PHP CMS",
     "license":"GPL-3.0",
     "require": {


### PR DESCRIPTION
Hi, Rubedo Team !

We'd like to be able to manage Rubedo Core as a Composer dependency for our projects (using our custom Rubedo Core installer plugin for Composer : https://github.com/Novactive/rubedo-core-installer).

For the installer to work, the Ruebdo package needs to be "typed" as "rubedo-core". Is it possible to integrate this into the official repo ?

Cheers !
